### PR TITLE
Fix KeyError: 'sym' in TSS demo notebooks under pandas >=2.2

### DIFF
--- a/TSS_non_transformed/Temporal_Similarity_Search_Non-Transformed_Demo.ipynb
+++ b/TSS_non_transformed/Temporal_Similarity_Search_Non-Transformed_Demo.ipynb
@@ -631,7 +631,7 @@
     "vecdf = df.groupby(['sym']).apply(\n",
     "    lambda x: pd.DataFrame({\n",
     "        'time': sliding_window_view(x['time'], D)[:, 0],  # Adjusted to keep the last time in the window\n",
-    "        'sym': x['sym'].iloc[0],\n",
+    "        'sym': x.name,\n",
     "        'price': list(sliding_window_view(x['price'], D))\n",
     "    })\n",
     ").reset_index(drop=True).reset_index()\n",

--- a/TSS_transformed/Temporal_Similarity_Search_Transformed_Demo.ipynb
+++ b/TSS_transformed/Temporal_Similarity_Search_Transformed_Demo.ipynb
@@ -297,7 +297,7 @@
     "D = 1000 # Sliding Window Size\n",
     "vecdf = df.groupby(['sym']).apply(\n",
     "    lambda x: pd.DataFrame({\n",
-    "        'sym': x['sym'].iloc[0],\n",
+    "        'sym': x.name,\n",
     "        'time': sliding_window_view(x['time'], D)[:, 0],  # Adjusted to keep the last time in the window\n",
     "        'price': list(sliding_window_view(x['price'], D))\n",
     "    })\n",


### PR DESCRIPTION
## What
Fixes `KeyError: 'sym'` raised when running the TSS demo notebooks with a recent pandas version.

Affected notebooks:
- `TSS_transformed/Temporal_Similarity_Search_Transformed_Demo.ipynb`
- `TSS_non_transformed/Temporal_Similarity_Search_Non-Transformed_Demo.ipynb`

## Why
Both notebooks build a vector column via:

```python
vecdf = df.groupby(['sym']).apply(
    lambda x: pd.DataFrame({
        'sym': x['sym'].iloc[0],
        ...
    })
)

## Fix
Replace x['sym'].iloc[0] with x.name in both notebooks — pandas sets .name to
the group key on the callback's sub-frame regardless of whether grouping columns are
included, so this works identically across old and new pandas without needing a
version-gated include_groups kwarg.